### PR TITLE
shell_lvl_handler actualizado

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/11 16:47:33 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/10/17 15:09:01 by vjan-nie         ###   ########.fr       */
+/*   Updated: 2025/10/18 15:10:57 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,9 @@
 # include "structs.h"
 # ifndef PATH_MAX
 #  define PATH_MAX 4096
+# endif
+# ifndef SHLVL_MAX
+#  define SHLVL_MAX 100
 # endif
 
 extern volatile sig_atomic_t	g_sigint_status;

--- a/src/env/environment_utils4.c
+++ b/src/env/environment_utils4.c
@@ -6,7 +6,7 @@
 /*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/17 15:08:07 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/10/17 15:12:21 by vjan-nie         ###   ########.fr       */
+/*   Updated: 2025/10/18 15:22:28 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -49,7 +49,13 @@ bool	shell_lvl_handler(t_data *data)
 	if (!shl_lvl)
 		return (no_shell_lvl(data));
 	int_value = ft_atoi(shl_lvl->value);
-	if (int_value < 1 || int_value >= 999)
+	if (int_value >= SHLVL_MAX)
+	{
+		ft_printf("Minishell: SHLVL too high (%d), exiting last one\n", int_value);
+		ft_cleanup_end(data);
+		exit(1);
+	}
+	if (int_value < 1)
 		int_value = 1;
 	else
 		int_value ++;


### PR DESCRIPTION
Hola! Le estaba dando vueltas al tema del SHLVL, y no me gustaba la solución que tenía. Subo esta pull para actualizar lo que creo que protege mejor al sistema. La idea es que si un script malicioso quiere abrir infinitos minishells anidados, no nos pete. Entonces defino un máximo razonable de niveles, por ejemplo 100. Si al arrancar minishell heredamos un lvl anómalo, menor que uno, o no está la variable, ponemos SHLVL=1. Si todo va bien, sumamos uno. Si alcanza el máximo establecido, imprime un mensaje de aviso y cierra el proceso actual. 

<img width="469" height="127" alt="Captura desde 2025-10-18 15-23-35" src="https://github.com/user-attachments/assets/005304b0-7a93-4ff2-9b7c-a1c6cb126863" />

<img width="711" height="586" alt="Captura desde 2025-10-18 15-24-05" src="https://github.com/user-attachments/assets/e29a7e6a-1f33-4679-9c0c-f8e901401975" />

Estaba pensando en aprovechar y hacer una función para cambiar la variable SHELL y poner nuestra minishell, pero hablando con la IA para ver qué peligros inesperados puede tener, parece ser meterse en un berenjenal que no compensa. Esa variable hace más referencia al uso de shell ejecutor por preferencia, y como nosotros tiramos con execve de binarios que entiendo que tienen alguna clase de dependencia, conviene dejarlo. Aquí lo que he visto: 

<img width="679" height="854" alt="Captura desde 2025-10-18 15-27-01" src="https://github.com/user-attachments/assets/026f5370-7c6b-4929-b082-2253db32f864" />

En fin, esa una pull cortita, pero siento que he arreglado algo que había dejado muy chapucero.
