### PR TITLE
Corrección issue + bonus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/01/17 12:24:16 by vjan-nie          #+#    #+#              #
-#    Updated: 2025/11/02 00:12:22 by vjan-nie         ###   ########.fr        #
+#    Updated: 2025/11/03 11:44:43 by vjan-nie         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -77,6 +77,7 @@ SRC		=	$(SRC_DIR)/$(CORE_DIR)/minishell.c\
 			$(SRC_DIR)/$(REDIR_DIR)/redir_utils2.c\
 			$(SRC_DIR)/$(REDIR_DIR)/heredoc.c\
 			$(SRC_DIR)/$(REDIR_DIR)/heredoc_utils.c\
+			$(SRC_DIR)/$(REDIR_DIR)/heredoc_utils2.c\
 			$(SRC_DIR)/$(REDIR_DIR)/heredoc_expanse.c\
 			$(SRC_DIR)/$(REDIR_DIR)/heredoc_expanse_utils.c\
 			$(SRC_DIR)/$(BUILTINS_DIR)/builtins.c\

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/11 16:47:33 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/11/02 01:22:51 by vjan-nie         ###   ########.fr       */
+/*   Updated: 2025/11/03 11:43:10 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -141,6 +141,8 @@ int				manage_heredoc(int heredoc_fd, int *fd, int *last_fd);
 int				manage_out_redir(t_redir *redir, int *fd, int *last_fd);
 void			heredoc_sigint_handler(int sign);
 int				heredoc_end(int status, int pipe_fd_readend);
+void			heredoc_canceled(char *true_limiter, int *pipe_fd);
+bool			is_limiter(char *limiter, char *line);
 
 /* ************************************************************************** */
 /* Heredoc expansor */

--- a/src/redirection/heredoc_utils2.c
+++ b/src/redirection/heredoc_utils2.c
@@ -1,0 +1,30 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   heredoc_utils2.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/11/03 11:40:42 by vjan-nie          #+#    #+#             */
+/*   Updated: 2025/11/03 11:42:21 by vjan-nie         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+void	heredoc_canceled(char *true_limiter, int *pipe_fd)
+{
+	ft_putstr_fd("minishell: warning: here-document didn't reach EOF\n", 2);
+	free(true_limiter);
+	close(pipe_fd[1]);
+	exit(EXIT_FAILURE);
+}
+
+bool	is_limiter(char *limiter, char *line)
+{
+	if (ft_strncmp(line, limiter, ft_strlen(limiter)) == 0 \
+	&& line[ft_strlen(limiter)] == '\n')
+		return (true);
+	else
+		return (false);
+}

--- a/src/redirection/heredoc_utils2.c
+++ b/src/redirection/heredoc_utils2.c
@@ -6,7 +6,7 @@
 /*   By: vjan-nie <vjan-nie@student.42madrid.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/11/03 11:40:42 by vjan-nie          #+#    #+#             */
-/*   Updated: 2025/11/03 11:42:21 by vjan-nie         ###   ########.fr       */
+/*   Updated: 2025/11/03 11:59:44 by vjan-nie         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,10 +14,10 @@
 
 void	heredoc_canceled(char *true_limiter, int *pipe_fd)
 {
-	ft_putstr_fd("minishell: warning: here-document didn't reach EOF\n", 2);
+	ft_putstr_fd("minishell: warning: here-document ended by EOF signal\n", 2);
 	free(true_limiter);
 	close(pipe_fd[1]);
-	exit(EXIT_FAILURE);
+	exit(EXIT_SUCCESS);
 }
 
 bool	is_limiter(char *limiter, char *line)


### PR DESCRIPTION
Lo he corregido, refactorizado y testeado. Va bien.

Me he dado cuenta de otra sutileza que es que en el proceso heredoc, puedes salir tb con cntrl + d, que es supuestamente señal de EOF, entonces no es una interrupción en teoría aunque se salga antes de encontrar el delimitador. Es como mandar un "vale por delimitador". Bashe sale con un warning pero limpio, y es un exit_success, así que así lo he puesto pero con un mensaje más claro según mi comprensión:

<img width="781" height="213" alt="Captura desde 2025-11-03 12-00-39" src="https://github.com/user-attachments/assets/421ad781-aa19-49ad-8f16-e9f915885c2d" />

<img width="836" height="442" alt="Captura desde 2025-11-03 12-00-22" src="https://github.com/user-attachments/assets/9108ba50-bcda-4831-882f-6f99d3abce97" />

